### PR TITLE
README updated to use redlobster.promise instead of redlobster.macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ for documentation on promises.
 ```clojure
     (ns user
       (:use [dogfort.http :only [run-http]])
-      (:use-macros [redlobster.macros :only [promise]]))
+      (:require [redlobster.promise :as p])
 
     (defn handler [request]
-      (promise {:status 200
-                :headers {:content-type "text/html"}
-                :body "<h1>This is Dog Fort</h1>"}))
+      (p/promise {:status 200
+                  :headers {:content-type "text/html"}
+                  :body "<h1>This is Dog Fort</h1>"}))
 
     (run-http handler {:port 1337})
 ```
@@ -36,11 +36,12 @@ object.
 ```clojure
     (ns user
       (:use [dogfort.http :only [run-http]])
-      (:require [redlobster.stream :as stream])
-      (:use-macros [redlobster.macros :only [promise]]))
+      (:require [redlobster.stream :as stream]
+                [redlobster.promise :as p])
+
 
     (defn handler [request]
-      (promise {:status 200
+      (p/promise {:status 200
                 :headers {:content-type "text/plain"}
                 :body (stream/slurp "README.md")}))
 


### PR DESCRIPTION
The promise macro doesn't realize the form passed to it. 
In redlobster.macro:

``` clojure
(defmacro promise
  "Return a promise that will be realised by the given forms. The functions
`realise` and `realise-error` will be available inside the macro body, and one
of these should be called at some point within the forms to realise the promise."
  [& forms]
  `(let [promise# (redlobster.promise/promise)
         realise# (fn [promise# value#]
                    (redlobster.promise/realise promise# value#))
         realise-error# (fn [promise# value#]
                          (redlobster.promise/realise-error promise# value#))
         ~'realise (partial realise# promise#)
         ~'realise-error (partial realise-error# promise#)]
;; forms is never passed to redlobster.promise to realise
     ~@forms
     promise#))
```

This is why I believe I get a timeout when I use this macro as a handler:

``` clojure
(defn handler [request]
      (promise {...}))
(run-http-server handler )
```
