### PR TITLE
added missing paren to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ for documentation on promises.
 ```clojure
     (ns user
       (:use [dogfort.http :only [run-http]])
-      (:require [redlobster.promise :as p])
+      (:require [redlobster.promise :as p]))
 
     (defn handler [request]
       (p/promise {:status 200


### PR DESCRIPTION
The "hello world" example was missing the closing paren for the `ns`.
